### PR TITLE
Add a refresh button if the workflow is still running

### DIFF
--- a/client/routes/workflow/components/graph-container.vue
+++ b/client/routes/workflow/components/graph-container.vue
@@ -28,7 +28,15 @@
       </div>
       <hr class="divider" />
       <div v-if="workflowLoading" id="loading"></div>
+      <button
+        v-if="!isWorkflowLoading"
+        id="refresh-btn"
+        v-on:click="reloadWorkflow()"
+      >
+        Refresh
+      </button>
       <WorkflowGraph
+        :key="componentKey"
         v-if="!workflowLoading"
         :workflow="workflow"
         :events="events"
@@ -62,7 +70,7 @@
 import store from "../../../store/index";
 import WorkflowGraph from "./cytoscape-graph.vue";
 export default {
-  props: ["workflow", "events"],
+  props: ["workflow", "events", "isWorkflowLoading"],
   components: {
     WorkflowGraph
   },
@@ -70,7 +78,8 @@ export default {
     return {
       workflowLoading: true,
       clickedId: null,
-      workflowName: null
+      workflowName: null,
+      componentKey: 0
     };
   },
   watch: {
@@ -93,6 +102,11 @@ export default {
         params: { workflowId: route.workflowId, runId: route.runId },
         query: this.$route.query
       });
+    },
+    reloadWorkflow() {
+      this.workflowLoading = true;
+      this.componentKey += 1;
+      this.delayedShow();
     },
     selectNode(node) {
       store.commit("setSelectedNode", node.data.id);
@@ -235,6 +249,17 @@ hr.divider {
       display: none;
     }
   }
+}
+
+#refresh-btn {
+  display: inline-block;
+  padding: 13px 21px;
+  transition: all 400ms ease;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: #fff;
+  background-color: #11939a;
+  white-space: nowrap;
 }
 
 /* ---- Loadig icon  ---- */

--- a/client/routes/workflow/components/graph-container.vue
+++ b/client/routes/workflow/components/graph-container.vue
@@ -28,8 +28,9 @@
       </div>
       <hr class="divider" />
       <div v-if="workflowLoading" id="loading"></div>
+      isloading: {{ isWorkflowRunning }} isfullyloaded: {{ isFullyLoaded }}
       <button
-        v-if="!isWorkflowLoading"
+        v-if="!isFullyLoaded"
         id="refresh-btn"
         v-on:click="reloadWorkflow()"
       >
@@ -70,7 +71,7 @@
 import store from "../../../store/index";
 import WorkflowGraph from "./cytoscape-graph.vue";
 export default {
-  props: ["workflow", "events", "isWorkflowLoading"],
+  props: ["workflow", "events", "isWorkflowRunning"],
   components: {
     WorkflowGraph
   },
@@ -79,7 +80,9 @@ export default {
       workflowLoading: true,
       clickedId: null,
       workflowName: null,
-      componentKey: 0
+      componentKey: 0,
+      eventsSnapShot: [],
+      isFullyLoaded: false
     };
   },
   watch: {
@@ -87,6 +90,19 @@ export default {
     runId: function() {
       this.resetData();
       this.setWorkFlow();
+    },
+    events: function() {
+      console.log(
+        "more events!",
+        this.eventsSnapShot.length,
+        this.events.length,
+        this.eventsSnapShot.length === this.events.length
+      );
+      this.isFullyLoaded =
+        this.eventsSnapShot.length === this.events.length &&
+        !this.isWorkflowRunning
+          ? true
+          : false;
     }
   },
   methods: {
@@ -104,6 +120,12 @@ export default {
       });
     },
     reloadWorkflow() {
+      this.eventsSnapShot = this.events;
+      this.isFullyLoaded =
+        this.eventsSnapShot.length === this.events.length &&
+        !this.isWorkflowRunning
+          ? true
+          : false;
       this.workflowLoading = true;
       this.componentKey += 1;
       this.delayedShow();
@@ -118,6 +140,7 @@ export default {
   },
   mounted() {
     this.delayedShow();
+    this.eventsSnapShot = this.events;
     store.commit("resetState");
   },
 

--- a/client/routes/workflow/components/graph-container.vue
+++ b/client/routes/workflow/components/graph-container.vue
@@ -27,18 +27,18 @@
         <div class="section-header-text">{{ workflowName }}</div>
       </div>
       <hr class="divider" />
-      <div v-if="workflowLoading" id="loading"></div>
-      isloading: {{ isWorkflowRunning }} isfullyloaded: {{ isFullyLoaded }}
+      <div v-if="isGraphLoading" id="loading"></div>
+      isloading: {{ isWorkflowRunning }} hasAllEvents: {{ hasAllEvents }}
       <button
-        v-if="!isFullyLoaded"
+        v-if="!hasAllEvents"
         id="refresh-btn"
         v-on:click="reloadWorkflow()"
       >
         Refresh
       </button>
       <WorkflowGraph
-        :key="componentKey"
-        v-if="!workflowLoading"
+        :key="forceRefresh"
+        v-if="!isGraphLoading"
         :workflow="workflow"
         :events="events"
       />
@@ -77,30 +77,25 @@ export default {
   },
   data() {
     return {
-      workflowLoading: true,
+      isGraphLoading: true,
       clickedId: null,
       workflowName: null,
-      componentKey: 0,
+      forceRefresh: true,
       eventsSnapShot: [],
-      isFullyLoaded: false
+      hasAllEvents: true
     };
   },
   watch: {
-    //We want to load a new workflow everytime we get a new runId
-    runId: function() {
-      this.resetData();
-      this.setWorkFlow();
-    },
     events: function() {
-      //We have more events than we have currently rendered
-      this.isFullyLoaded = false;
+      //We have more events coming in
+      this.hasAllEvents = false;
     }
   },
   methods: {
     delayedShow() {
       let delay = 500;
       setTimeout(() => {
-        this.workflowLoading = false;
+        this.isGraphLoading = false;
       }, delay);
     },
     updateRoute(route) {
@@ -112,22 +107,14 @@ export default {
     },
     reloadWorkflow() {
       this.eventsSnapShot = this.events;
-      this.isFullyLoaded =
-        this.eventsSnapShot.length === this.events.length &&
-        !this.isWorkflowRunning
-          ? true
-          : false;
-      this.workflowLoading = true;
-      this.componentKey += 1;
+      this.isGraphLoading = true;
+      this.forceRefresh = !this.forceRefresh;
       this.delayedShow();
-      this.isFullyLoaded = true;
+      //We currently show all available events, refresh btn should be hidden
+      this.hasAllEvents = true;
     },
     selectNode(node) {
       store.commit("setSelectedNode", node.data.id);
-    },
-    resetData() {
-      store.commit("resetState"); //We reset the state every time we load a new workflow
-      this.workflowLoading = false;
     }
   },
   mounted() {

--- a/client/routes/workflow/components/graph-container.vue
+++ b/client/routes/workflow/components/graph-container.vue
@@ -28,7 +28,6 @@
       </div>
       <hr class="divider" />
       <div v-if="isGraphLoading" id="loading"></div>
-      isloading: {{ isWorkflowRunning }} hasAllEvents: {{ hasAllEvents }}
       <button
         v-if="!hasAllEvents"
         id="refresh-btn"
@@ -93,7 +92,7 @@ export default {
   },
   methods: {
     delayedShow() {
-      let delay = 500;
+      let delay = 400;
       setTimeout(() => {
         this.isGraphLoading = false;
       }, delay);

--- a/client/routes/workflow/components/graph-container.vue
+++ b/client/routes/workflow/components/graph-container.vue
@@ -92,17 +92,8 @@ export default {
       this.setWorkFlow();
     },
     events: function() {
-      console.log(
-        "more events!",
-        this.eventsSnapShot.length,
-        this.events.length,
-        this.eventsSnapShot.length === this.events.length
-      );
-      this.isFullyLoaded =
-        this.eventsSnapShot.length === this.events.length &&
-        !this.isWorkflowRunning
-          ? true
-          : false;
+      //We have more events than we have currently rendered
+      this.isFullyLoaded = false;
     }
   },
   methods: {
@@ -129,6 +120,7 @@ export default {
       this.workflowLoading = true;
       this.componentKey += 1;
       this.delayedShow();
+      this.isFullyLoaded = true;
     },
     selectNode(node) {
       store.commit("setSelectedNode", node.data.id);

--- a/client/routes/workflow/history.vue
+++ b/client/routes/workflow/history.vue
@@ -9,7 +9,9 @@
   >
     <header class="controls">
       <div class="view-format">
-        <label for="format">View Format</label>
+        <label for="format"
+          >View Format + {{ isWorkflowRunning }} {{ loading }}
+        </label>
         <div class="view-formats">
           <a
             href="#"
@@ -65,6 +67,7 @@
         <DagGraphContainer
           :workflow="workflow"
           :events="events"
+          :isWorkflowRunning="isWorkflowRunning"
           class="tree-view"
           v-if="this.graphView === 'dagGraph'"
         ></DagGraphContainer>
@@ -354,6 +357,7 @@ export default {
     "runId",
     "graphView",
     "timelineEvents",
+    "isWorkflowRunning",
     "workflowHistoryEventHighlightList",
     "workflowHistoryEventHighlightListEnabled",
     "workflowId"

--- a/client/routes/workflow/history.vue
+++ b/client/routes/workflow/history.vue
@@ -9,9 +9,7 @@
   >
     <header class="controls">
       <div class="view-format">
-        <label for="format"
-          >View Format + {{ isWorkflowRunning }} {{ loading }}
-        </label>
+        <label for="format">View Format </label>
         <div class="view-formats">
           <a
             href="#"

--- a/client/routes/workflow/history.vue
+++ b/client/routes/workflow/history.vue
@@ -67,7 +67,7 @@
           :events="events"
           :isWorkflowRunning="isWorkflowRunning"
           class="tree-view"
-          v-if="this.graphView === 'dagGraph'"
+          v-if="this.graphView === 'dagGraph' && events.length"
         ></DagGraphContainer>
         <timeline
           :events="timelineEvents"

--- a/client/routes/workflow/index.vue
+++ b/client/routes/workflow/index.vue
@@ -47,6 +47,7 @@
       name="history"
       :baseAPIURL="baseAPIURL"
       :events="historyEvents"
+      :isWorkflowRunning="isWorkflowRunning"
       :loading="history.loading"
       :timelineEvents="historyTimelineEvents"
       :workflow-history-event-highlight-list="workflowHistoryEventHighlightList"
@@ -73,15 +74,15 @@
 </template>
 
 <script>
-import { RETRY_COUNT_MAX, RETRY_TIMEOUT } from './constants';
+import { RETRY_COUNT_MAX, RETRY_TIMEOUT } from "./constants";
 import {
   getHistoryEvents,
   getHistoryTimelineEvents,
-  getSummary,
-} from './helpers';
-import { NOTIFICATION_TYPE_ERROR } from '~constants';
-import { getErrorMessage } from '~helpers';
-import { NavigationBar, NavigationLink } from '~components';
+  getSummary
+} from "./helpers";
+import { NOTIFICATION_TYPE_ERROR } from "~constants";
+import { getErrorMessage } from "~helpers";
+import { NavigationBar, NavigationLink } from "~components";
 
 export default {
   data() {
@@ -95,7 +96,7 @@ export default {
       workflow: undefined,
 
       history: {
-        loading: undefined,
+        loading: undefined
       },
 
       summary: {
@@ -104,33 +105,33 @@ export default {
         parentWorkflowRoute: undefined,
         result: undefined,
         wfStatus: undefined,
-        workflow: undefined,
+        workflow: undefined
       },
 
-      unwatch: [],
+      unwatch: []
     };
   },
   props: [
-    'dateFormat',
-    'domain',
-    'runId',
-    'timeFormat',
-    'timezone',
-    'workflowHistoryEventHighlightList',
-    'workflowHistoryEventHighlightListEnabled',
-    'workflowId',
+    "dateFormat",
+    "domain",
+    "runId",
+    "timeFormat",
+    "timezone",
+    "workflowHistoryEventHighlightList",
+    "workflowHistoryEventHighlightListEnabled",
+    "workflowId"
   ],
   created() {
     this.unwatch.push(
-      this.$watch('baseAPIURL', this.onBaseApiUrlChange, { immediate: true })
+      this.$watch("baseAPIURL", this.onBaseApiUrlChange, { immediate: true })
     );
   },
   beforeDestroy() {
     this.clearWatches();
   },
   components: {
-    'navigation-bar': NavigationBar,
-    'navigation-link': NavigationLink,
+    "navigation-bar": NavigationBar,
+    "navigation-link": NavigationLink
   },
   computed: {
     baseAPIURL() {
@@ -147,7 +148,7 @@ export default {
         timeFormat,
         timezone,
         workflowHistoryEventHighlightList,
-        workflowHistoryEventHighlightListEnabled,
+        workflowHistoryEventHighlightListEnabled
       } = this;
 
       return getHistoryEvents({
@@ -156,7 +157,7 @@ export default {
         timeFormat,
         timezone,
         workflowHistoryEventHighlightList,
-        workflowHistoryEventHighlightListEnabled,
+        workflowHistoryEventHighlightListEnabled
       });
     },
     historyTimelineEvents() {
@@ -174,7 +175,7 @@ export default {
       return `${queryUrl}&nextPageToken=${encodeURIComponent(
         this.nextPageToken
       )}`;
-    },
+    }
   },
   methods: {
     clearState() {
@@ -250,11 +251,11 @@ export default {
           this.summary = getSummary({
             events: this.events,
             isWorkflowRunning: this.isWorkflowRunning,
-            workflow: this.workflow,
+            workflow: this.workflow
           });
 
           if (shouldHighlightEventId) {
-            this.$emit('highlight-event-id', this.$route.query.eventId);
+            this.$emit("highlight-event-id", this.$route.query.eventId);
           }
 
           this.fetchHistoryPageRetryCount = 0;
@@ -270,9 +271,9 @@ export default {
             return;
           }
 
-          this.$emit('onNotification', {
+          this.$emit("onNotification", {
             message: getErrorMessage(error),
-            type: NOTIFICATION_TYPE_ERROR,
+            type: NOTIFICATION_TYPE_ERROR
           });
 
           this.fetchHistoryPageRetryCount += 1;
@@ -303,9 +304,9 @@ export default {
             this.baseApiUrlRetryCount = 0;
           },
           error => {
-            this.$emit('onNotification', {
+            this.$emit("onNotification", {
               message: getErrorMessage(error),
-              type: NOTIFICATION_TYPE_ERROR,
+              type: NOTIFICATION_TYPE_ERROR
             });
             this.baseApiUrlRetryCount += 1;
             setTimeout(
@@ -322,17 +323,17 @@ export default {
       this.fetchHistoryPage(queryUrl);
     },
     onNotification(event) {
-      this.$emit('onNotification', event);
+      this.$emit("onNotification", event);
     },
     onWorkflowHistoryEventParamToggle(event) {
-      this.$emit('onWorkflowHistoryEventParamToggle', event);
+      this.$emit("onWorkflowHistoryEventParamToggle", event);
     },
     setupQueryUrlWatch() {
       this.clearQueryUrlWatch();
       this.unwatch.push(
-        this.$watch('queryUrl', this.onQueryUrlChange, { immediate: true })
+        this.$watch("queryUrl", this.onQueryUrlChange, { immediate: true })
       );
-    },
-  },
+    }
+  }
 };
 </script>


### PR DESCRIPTION
I wrote functionality to check if a workflow is still running (not finished), and showing/hiding a refresh button if there are more events to show on the graph.

The prop "events" contains the current fetched events of a workflow.I am watching if the prop "events" for changes, and if so I show the refresh button. The refresh btn then toggles a data value which is bound to the graph component - so it forces a refresh of that graph every time the user presses the refresh btn.

Would like some feedback if there is a better way to do it :)